### PR TITLE
Make keyboard selections in list/tree visible

### DIFF
--- a/themes/arc-dark-monochrome.json
+++ b/themes/arc-dark-monochrome.json
@@ -9,7 +9,7 @@
         "dropdown.background": "#1d1f23",
         "dropdown.border": "#181a1f",
         "list.focusBackground": "#383e4a",
-        "list.activeSelectionBackground": "#2f343f",
+        "list.activeSelectionBackground": "#292d35",
         "list.activeSelectionForeground": "#d7dae0",
         "list.inactiveSelectionBackground": "#21252b",
         "list.inactiveSelectionForeground": "#d7dae0",


### PR DESCRIPTION
Currently, if I select something in the command palette using the arrow keys, I cannot tell which list item is selected. If I hover with my mouse, I can see it fine. I (think I) changed the background color of the selected list item to the same as the hover color. I have never made a theme before so I may have done something wrong, but according to [this article](https://code.visualstudio.com/docs/getstarted/themes), I think I did this correctly.