### PR TITLE
feat: set highlight color on quickInputList

### DIFF
--- a/themes/arc-dark-monochrome.json
+++ b/themes/arc-dark-monochrome.json
@@ -16,6 +16,7 @@
 		"list.hoverBackground": "#292d35",
 		"list.dropBackground": "#383b3d",
 		"list.highlightForeground": "#c5c5c5",
+		"quickInputList.focusBackground": "#181a1f",
 		"button.background": "#404754",
 		"badge.background": "#21252b",
 		"scrollbarSlider.background": "#4e566680",

--- a/themes/arc-plus.json
+++ b/themes/arc-plus.json
@@ -16,6 +16,7 @@
 		"list.hoverBackground": "#292d35",
 		"list.dropBackground": "#383b3d",
 		"list.highlightForeground": "#c5c5c5",
+		"quickInputList.focusBackground": "#181a1f",
 		"button.background": "#404754",
 		"badge.background": "#21252b",
 		"scrollbarSlider.background": "#4e566680",


### PR DESCRIPTION
Define a color hightlight to quick Input list.
![highlight_color](https://github.com/phil-harmoniq/arc-plus/assets/1899604/6ad6c161-1b3b-4c5e-8591-a1ee2ecd4de3)
