### PR TITLE
feat: set high light for quick input list

### DIFF
--- a/themes/arc-dark-monochrome.json
+++ b/themes/arc-dark-monochrome.json
@@ -16,6 +16,7 @@
         "list.hoverBackground": "#292d35",
         "list.dropBackground": "#383b3d",
         "list.highlightForeground": "#c5c5c5",
+		"quickInputList.focusBackground": "#181a1f",
         "menubar.selectionBackground": "#2f343f",
         "button.background": "#404754",
         "badge.background": "#21252b",

--- a/themes/arc-plus.json
+++ b/themes/arc-plus.json
@@ -16,6 +16,7 @@
         "list.hoverBackground": "#292d35",
         "list.dropBackground": "#383b3d",
         "list.highlightForeground": "#c5c5c5",
+		"quickInputList.focusBackground": "#181a1f",
         "menubar.selectionBackground": "#2f343f",
         "button.background": "#404754",
         "badge.background": "#21252b",


### PR DESCRIPTION
Define a highlight color for quick input list.
![highlight_color](https://github.com/phil-harmoniq/arc-plus/assets/1899604/001743f3-5127-4289-b92d-fae7e0558385)
